### PR TITLE
FIX: uncommented method in tests

### DIFF
--- a/src/test/java/arsw/wherewe/back/mazorcausers/MazorcausersApplicationTests.java
+++ b/src/test/java/arsw/wherewe/back/mazorcausers/MazorcausersApplicationTests.java
@@ -7,8 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @SpringBootTest
 class MazorcausersApplicationTests {
 
+
 	@Test
 	void contextLoads() {
+		// this method is empty because it is not necessary
 	}
 
 	@Test


### PR DESCRIPTION
This pull request includes a small change to the `MazorcausersApplicationTests.java` file. The change adds a comment to the `contextLoads` method indicating that it is intentionally left empty because it is not necessary.