### PR TITLE
FIX:problems of sonar cloud assestment

### DIFF
--- a/src/main/java/arsw/wherewe/back/mazorcausers/config/CorsConfig.java
+++ b/src/main/java/arsw/wherewe/back/mazorcausers/config/CorsConfig.java
@@ -9,11 +9,11 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class CorsConfig implements WebMvcConfigurer {
     /**
      * Add CORS mappings
-     * @param registry
+     * @param registry CorsRegistry
      */
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        //Permitir todos los origenes
+        //Allow all origins, methods, and headers
         registry.addMapping("/**")
                 .allowedOrigins("*")
                 .allowedMethods("GET", "POST", "PUT", "DELETE")

--- a/src/main/java/arsw/wherewe/back/mazorcausers/controller/UserController.java
+++ b/src/main/java/arsw/wherewe/back/mazorcausers/controller/UserController.java
@@ -20,7 +20,7 @@ public class UserController {
 
     /**
      * Constructor for UserController injecting UserService
-     * @param userService
+     * @param userService UserService
      */
     @Autowired
     public UserController(UserService userService) {
@@ -29,7 +29,7 @@ public class UserController {
 
     /**
      * Create a new user
-     * @param user
+     * @param user User
      * @return ResponseEntity<User>
      */
     @PostMapping("")

--- a/src/main/java/arsw/wherewe/back/mazorcausers/service/UserService.java
+++ b/src/main/java/arsw/wherewe/back/mazorcausers/service/UserService.java
@@ -14,8 +14,13 @@ import java.util.Optional;
 @Service
 public class UserService {
 
-    @Autowired
+
     private UserRepository userRepository;
+
+    @Autowired
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
 
     /**
      * Create a new user if it does not exist

--- a/src/test/java/arsw/wherewe/back/mazorcausers/controller/UserControllerTests.java
+++ b/src/test/java/arsw/wherewe/back/mazorcausers/controller/UserControllerTests.java
@@ -14,7 +14,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-public class UserControllerTests {
+class UserControllerTests {
 
     @Mock
     private UserService userService;
@@ -33,7 +33,7 @@ public class UserControllerTests {
 
         ResponseEntity<User> response = userController.createUser(user);
 
-        assertEquals(200, response.getStatusCodeValue());
+        assertEquals(200, response.getStatusCode().value());
         assertEquals(user, response.getBody());
     }
 
@@ -44,7 +44,7 @@ public class UserControllerTests {
 
         ResponseEntity<User> response = userController.createUser(user);
 
-        assertEquals(400, response.getStatusCodeValue());
+        assertEquals(400, response.getStatusCode().value());
         assertNull(response.getBody());
     }
 
@@ -57,7 +57,7 @@ public class UserControllerTests {
 
         ResponseEntity<List<User>> response = userController.getAllUsers();
 
-        assertEquals(200, response.getStatusCodeValue());
+        assertEquals(200, response.getStatusCode().value());
         assertEquals(users, response.getBody());
     }
 
@@ -67,7 +67,7 @@ public class UserControllerTests {
 
         ResponseEntity<List<User>> response = userController.getAllUsers();
 
-        assertEquals(204, response.getStatusCodeValue());
+        assertEquals(204, response.getStatusCode().value());
         assertNull(response.getBody());
     }
 }

--- a/src/test/java/arsw/wherewe/back/mazorcausers/model/UserTests.java
+++ b/src/test/java/arsw/wherewe/back/mazorcausers/model/UserTests.java
@@ -3,7 +3,7 @@ package arsw.wherewe.back.mazorcausers.model;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class UserTests {
+class UserTests {
 
     @Test
     void userConstructorAndGetters() {


### PR DESCRIPTION
This pull request includes several changes to improve code documentation, add a constructor to the `UserService` class, and update test assertions. The most important changes include adding parameter descriptions, modifying test assertions, and updating class definitions.

Documentation improvements:

* [`src/main/java/arsw/wherewe/back/mazorcausers/config/CorsConfig.java`](diffhunk://#diff-038ac648f7826c6cf3efdd7a123502dfe8f99ba34d6a3ec255fdf31345d6673fL12-R16): Updated the comment to clarify that all origins, methods, and headers are allowed.
* [`src/main/java/arsw/wherewe/back/mazorcausers/controller/UserController.java`](diffhunk://#diff-7d90ab4002f67e3155bec9e44035c403190b4a24915a83f0201e36d2dd0bed5fL23-R23): Added parameter descriptions for `UserService` and `User` in the constructor and `createUser` method respectively. [[1]](diffhunk://#diff-7d90ab4002f67e3155bec9e44035c403190b4a24915a83f0201e36d2dd0bed5fL23-R23) [[2]](diffhunk://#diff-7d90ab4002f67e3155bec9e44035c403190b4a24915a83f0201e36d2dd0bed5fL32-R32)

Code enhancements:

* [`src/main/java/arsw/wherewe/back/mazorcausers/service/UserService.java`](diffhunk://#diff-f965e15a81f113ba868957e50fdf1ad65e5b2aa9cb5fa153f71aa74f93a4f44bL17-R24): Added a constructor to inject `UserRepository` and removed the field-level `@Autowired` annotation.

Test updates:

* [`src/test/java/arsw/wherewe/back/mazorcausers/controller/UserControllerTests.java`](diffhunk://#diff-ec258c795f07208ef31202c4c4d2032c206d396a65f75a67f68bb56ede6f01f1L36-R36): Changed test assertions to use `response.getStatusCode().value()` instead of `response.getStatusCodeValue()`. [[1]](diffhunk://#diff-ec258c795f07208ef31202c4c4d2032c206d396a65f75a67f68bb56ede6f01f1L36-R36) [[2]](diffhunk://#diff-ec258c795f07208ef31202c4c4d2032c206d396a65f75a67f68bb56ede6f01f1L47-R47) [[3]](diffhunk://#diff-ec258c795f07208ef31202c4c4d2032c206d396a65f75a67f68bb56ede6f01f1L60-R60) [[4]](diffhunk://#diff-ec258c795f07208ef31202c4c4d2032c206d396a65f75a67f68bb56ede6f01f1L70-R70)
* [`src/test/java/arsw/wherewe/back/mazorcausers/model/UserTests.java`](diffhunk://#diff-6aea224c9c143cca111232008b4464eb3e2c5449a0e90efb9154a87afec62ad8L6-R6): Updated the class definition to use a package-private class instead of a public class.