### PR TITLE
ADD:getById endpoint

### DIFF
--- a/src/main/java/arsw/wherewe/back/mazorcausers/controller/UserController.java
+++ b/src/main/java/arsw/wherewe/back/mazorcausers/controller/UserController.java
@@ -54,4 +54,18 @@ public class UserController {
         }
         return ResponseEntity.ok(users);
     }
+
+    /**
+     * Get User by Id
+     * @param id String
+     * @return ResponseEntity<User>
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<User> getUserById(@PathVariable("id") String id) {
+        User user = userService.getUserById(id);
+        if(user == null){
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(user);
+    }
 }

--- a/src/main/java/arsw/wherewe/back/mazorcausers/service/UserService.java
+++ b/src/main/java/arsw/wherewe/back/mazorcausers/service/UserService.java
@@ -45,4 +45,13 @@ public class UserService {
     public List<User> getAllUsers() {
         return userRepository.findAll();
     }
+
+    /**
+     * Get User by Id
+     * @param id String
+     * @return User or null
+     */
+    public User getUserById(String id) {
+        return userRepository.findById(id).orElse(null);
+    }
 }

--- a/src/test/java/arsw/wherewe/back/mazorcausers/controller/UserControllerTests.java
+++ b/src/test/java/arsw/wherewe/back/mazorcausers/controller/UserControllerTests.java
@@ -70,4 +70,25 @@ class UserControllerTests {
         assertEquals(204, response.getStatusCode().value());
         assertNull(response.getBody());
     }
+
+    @Test
+    void getUserByIdSuccessfully() {
+        User user = new User("1", "John", "John Doe", "john.doe@example.com", "UTC");
+        when(userService.getUserById("1")).thenReturn(user);
+
+        ResponseEntity<User> response = userController.getUserById("1");
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(user, response.getBody());
+    }
+
+    @Test
+    void getUserByIdNotFound() {
+        when(userService.getUserById("1")).thenReturn(null);
+
+        ResponseEntity<User> response = userController.getUserById("1");
+
+        assertEquals(404, response.getStatusCode().value());
+        assertNull(response.getBody());
+    }
 }

--- a/src/test/java/arsw/wherewe/back/mazorcausers/service/UserServiceTest.java
+++ b/src/test/java/arsw/wherewe/back/mazorcausers/service/UserServiceTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -64,5 +65,25 @@ class UserServiceTest {
         List<User> result = userService.getAllUsers();
 
         assertEquals(users, result);
+    }
+
+    @Test
+    void getUserById_userExists() {
+        User user = new User();
+        user.setId("1");
+        when(userRepository.findById("1")).thenReturn(Optional.of(user));
+
+        User result = userService.getUserById("1");
+
+        assertEquals(user, result);
+    }
+
+    @Test
+    void getUserById_userDoesNotExist() {
+        when(userRepository.findById("1")).thenReturn(Optional.empty());
+
+        User result = userService.getUserById("1");
+
+        assertNull(result);
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature to retrieve a user by their ID in the `mazorcausers` module. The changes include updates to the `UserController` and `UserService` classes, as well as the addition of corresponding unit tests.

### New Feature: Retrieve User by ID

* [`src/main/java/arsw/wherewe/back/mazorcausers/controller/UserController.java`](diffhunk://#diff-7d90ab4002f67e3155bec9e44035c403190b4a24915a83f0201e36d2dd0bed5fR57-R70): Added a new endpoint `getUserById` to fetch a user by their ID.
* [`src/main/java/arsw/wherewe/back/mazorcausers/service/UserService.java`](diffhunk://#diff-f965e15a81f113ba868957e50fdf1ad65e5b2aa9cb5fa153f71aa74f93a4f44bR48-R56): Implemented the `getUserById` method to retrieve a user from the repository by their ID.

### Unit Tests

* [`src/test/java/arsw/wherewe/back/mazorcausers/controller/UserControllerTests.java`](diffhunk://#diff-ec258c795f07208ef31202c4c4d2032c206d396a65f75a67f68bb56ede6f01f1R73-R93): Added tests for the `getUserById` endpoint to verify successful retrieval and handling of non-existent users.
* [`src/test/java/arsw/wherewe/back/mazorcausers/service/UserServiceTest.java`](diffhunk://#diff-592e73adc89b676925239cfb4a98b30446ab7cb6f76567784e7c51523e72e31cR69-R88): Added tests for the `getUserById` method in the `UserService` class to check both existing and non-existing user scenarios.
* [`src/test/java/arsw/wherewe/back/mazorcausers/service/UserServiceTest.java`](diffhunk://#diff-592e73adc89b676925239cfb4a98b30446ab7cb6f76567784e7c51523e72e31cR15): Imported `assertNull` for testing purposes.